### PR TITLE
Fix: Resolve admin login not moving past login screen

### DIFF
--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -40,7 +40,16 @@ export const signInWithEmail = createAsyncThunk(
             creationTime: new Date().toISOString(),
             lastSignInTime: new Date().toISOString(),
           },
-          providerData: [],
+          providerData: [
+            {
+              uid: 'test-admin-uid', // Typically matches the main uid for password auth
+              email: 'admin@travelgo.com',
+              displayName: 'Test Admin',
+              phoneNumber: null,
+              photoURL: null,
+              providerId: 'password', // Important: indicates email/password authentication
+            },
+          ],
           refreshToken: 'mock-refresh-token',
           tenantId: null,
           delete: async () => {},


### PR DESCRIPTION
The application was getting stuck on the login screen when using the hardcoded 'admin/admin' credentials. This was due to an incomplete mock User object being generated for this test user.

Specifically, the `providerData` array in the mock User object was empty. Subsequent parts of the application likely tried to access `user.providerData[0]`, leading to a runtime error that prevented navigation to the main application screens.

This commit populates the `providerData` array with a realistic mock `UserInfo` object for an email/password authenticated user. This ensures that accesses to `user.providerData[0]` will not fail and allows the admin user to successfully log in and navigate to the main application.